### PR TITLE
Prevent CSP usage in WP admin

### DIFF
--- a/content-security-policy/README.md
+++ b/content-security-policy/README.md
@@ -76,7 +76,10 @@ class Security {
             form-action 'self';
             script-src 'self' " . implode( ' ', $scripts ) . ";";
 
-    header("Content-Security-Policy: " . trim( preg_replace( '/\s+/', ' ', $csp ) ) );
+    // Don't use CSP in WP admin
+    if ( ! is_admin() ) {
+      header("Content-Security-Policy: " . trim( preg_replace( '/\s+/', ' ', $csp ) ) );
+    }
   }
 }
 ```


### PR DESCRIPTION
This prevents usage of custom Content Security Policy in WP admin as there are too many inline scripts and styles to make it work in a reasonable way.